### PR TITLE
Detach after element when not truncated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "dotdotdot",
+  "version": "1.7.3",
+  "description": "A jQuery plugin for advanced cross-browser ellipsis on multiple line content.",
+  "homepage": "http://dotdotdot.frebsite.nl/",
+  "author": {
+    "name": "Fred Heusschen",
+    "email": "info@frebsite.nl"
+  },
+  "dependencies": {
+    "jquery": ">= 1.4.3"
+  }
+}

--- a/src/js/jquery.dotdotdot.js
+++ b/src/js/jquery.dotdotdot.js
@@ -156,7 +156,7 @@
 
 			).bind(
 				'destroy.dot',
-				function( e )
+				function( e, fn )
 				{
 					e.preventDefault();
 					e.stopPropagation();
@@ -169,6 +169,10 @@
 						.append( orgContent )
 						.attr( 'style', $dot.data( 'dotdotdot-style' ) || '' )
 						.data( 'dotdotdot', false );
+					if ( typeof fn == 'function' )
+					{
+						fn.call( $dot[ 0 ] );
+					}
 				}
 			);
 			return $dot;

--- a/src/js/jquery.dotdotdot.js
+++ b/src/js/jquery.dotdotdot.js
@@ -1,5 +1,5 @@
 /*
- *	jQuery dotdotdot 1.7.2
+ *	jQuery dotdotdot 1.7.3
  *
  *	Copyright (c) Fred Heusschen
  *	www.frebsite.nl

--- a/src/js/jquery.dotdotdot.js
+++ b/src/js/jquery.dotdotdot.js
@@ -77,6 +77,16 @@
 						}
 					}
 
+					var after = false,
+						trunc = false;
+
+					if ( conf.afterElement )
+					{
+						after = conf.afterElement.clone( true );
+						after.show();
+						conf.afterElement.detach();
+					}
+
 					$inr = $dot.wrapInner( '<div class="dotdotdot" />' ).children();
 					$inr.contents()
 						.detach()
@@ -92,16 +102,6 @@
 							'padding'	: 0,
 							'margin'	: 0
 						});
-
-					var after = false,
-						trunc = false;
-
-					if ( conf.afterElement )
-					{
-						after = conf.afterElement.clone( true );
-					    after.show();
-						conf.afterElement.detach();
-					}
 
 					if ( test( $inr, opts ) )
 					{

--- a/src/js/jquery.dotdotdot.js
+++ b/src/js/jquery.dotdotdot.js
@@ -355,6 +355,13 @@
 					var e	= this,
 						$e	= $(e);
 
+					var addAfter = function(elem) {
+						if ( after && !$e.is( o.after ) && !$e.find( o.after ).length  )
+						{
+							elem[ elem.is( notx ) ? 'after' : 'append' ]( after );
+						}
+					};
+
 					if ( typeof e == 'undefined' || ( e.nodeType == 3 && $.trim( e.data ).length == 0 ) )
 					{
 						return true;
@@ -370,10 +377,7 @@
 					else
 					{
 						$elem.append( $e );
-						if ( after && !$e.is( o.after ) && !$e.find( o.after ).length  )
-						{
-							$elem[ $elem.is( notx ) ? 'after' : 'append' ]( after );
-						}
+						addAfter( $elem );
 						if ( test( $i, o ) )
 						{
 							if ( e.nodeType == 3 ) // node is TEXT
@@ -387,7 +391,9 @@
 
 							if ( !isTruncated )
 							{
-								$e.detach();
+								var txt = addEllipsis( getTextContent( e ), o );
+								setTextContent( e, txt );
+								addAfter( $e );
 								isTruncated = true;
 							}
 						}


### PR DESCRIPTION
This fixes a problem where the after element (e.g., a "Read More" link) would appear even with short content that does not need truncation.

It also includes these enhancements:
- the `destroy.dot` event handler accepts an optional callback parameter
- a new `package.json` allows proper installation with `npm`
